### PR TITLE
[Feat/#77] 리뷰 하트/별점/사진 상세 UI 구현

### DIFF
--- a/src/components/modal/imageModal.tsx
+++ b/src/components/modal/imageModal.tsx
@@ -4,20 +4,18 @@ import { useRef, useState } from 'react';
 import type { Swiper as SwiperType } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-import { REVIEW_LIST } from '@/constants/product/reviews';
-
 import { useModalStore } from '@/stores/modalStore';
 
 import Close from '@/assets/icons/modalClose.svg?react';
 import Next from '@/assets/icons/next.svg?react';
 import Prev from '@/assets/icons/prev.svg?react';
 
-export default function ImageModal(props?: Record<string, string | number>) {
-  const imageList = REVIEW_LIST.flatMap(({ images }) => images);
+export default function ImageModal(props: Record<string | number, string[]>) {
+  const imageList = props.imageList;
   const { closeModal } = useModalStore();
 
-  const startIdx = imageList.findIndex((img) => img === String(props?.src));
-  const [currentIndex, setCurrentIndex] = useState(startIdx);
+  const startIdx = imageList.findIndex((img) => img === String(props.src));
+  const [currentIndex, setCurrentIndex] = useState(startIdx >= 0 ? startIdx : 0);
   const swiperRef = useRef<SwiperType | null>(null);
 
   const handleMove = (offset: number) => {

--- a/src/components/product/reviewCard.tsx
+++ b/src/components/product/reviewCard.tsx
@@ -7,6 +7,7 @@ import StarRating from '@/components/product/starRating';
 
 import Heart from '@/assets/icons/heart.svg?react';
 import HeartFill from '@/assets/icons/heartFill.svg?react';
+import { REVIEW_LIST } from '@/constants/product/reviews';
 
 type TReviewCardProps = {
   data: {
@@ -85,7 +86,7 @@ export default function ReviewCard({ data }: TReviewCardProps) {
       <section className="flex items-center gap-2">
         {images.slice(0, 4).map((img, idx) => (
           <div key={idx} className="relative">
-            <img src={img} onClick={() => openModal('image', { src: img })} />
+            <img src={img} onClick={() => openModal('image', { src: img, imageList: REVIEW_LIST.flatMap(({ images }) => images)})} />
             {idx === 3 && images.length > 4 && (
               <div
                 className="flex justify-center items-center text-white text-body-regular absolute top-0 left-0 bg-[#00000099] w-full h-full"

--- a/src/components/review/reviewItem.tsx
+++ b/src/components/review/reviewItem.tsx
@@ -3,7 +3,9 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { useModalStore } from '@/stores/modalStore';
 
 import type { IMyReview } from '@/mocks/reviewData';
-
+import Heart from '@/assets/icons/heart.svg?react';
+import HeartFill from '@/assets/icons/heartFill.svg?react';
+import StarRating from '../product/starRating';
 interface IReviewDataProps {
   item: IMyReview;
 }
@@ -12,6 +14,7 @@ export default function ReviewItem({ item }: IReviewDataProps) {
   const [expanded, setExpanded] = useState(false);
   const [isOverflow, setIsOverflow] = useState(false);
   const pRef = useRef<HTMLParagraphElement>(null);
+  const [liked, setLiked] = useState(false);
   const { openModal } = useModalStore();
 
   useLayoutEffect(() => {
@@ -31,9 +34,9 @@ export default function ReviewItem({ item }: IReviewDataProps) {
             삭제
           </button>
         </div>
-        <div>
-          {/* 별도 컴포넌트로 추후 구현 예정 */}
-          <span className="text-body-medium text-[#FFC800]">{item.starRating}</span>
+        <div className="flex items-center justify-center gap-1">
+          <StarRating w={16} h={16} star={item.starRating} />
+          <p className="text-body-medium text-[#FFC800]">{item.starRating}</p>
         </div>
         <div className="text-black text-body-regular">
           <p>{item.name}</p>
@@ -56,14 +59,30 @@ export default function ReviewItem({ item }: IReviewDataProps) {
         </div>
       </div>
       <div className="w-full flex items-center justify-start gap-2 py-3">
-        {/* 4장 이상 처리 상세보기 구현 예정 */}
         {item.images?.slice(0, 4).map((url: string, index: number) => (
-          <img key={index} src={url} alt={`Review image ${index + 1}`} className="w-19 h-19 object-cover" />
+          <div key={index} className="relative">
+            <img
+              src={url}
+              alt={`Review image ${index + 1}`}
+              onClick={() => openModal('image', { src: url, imageList: item.images })}
+              className="w-19 h-19 object-cover"
+            />
+            {index === 3 && item.images && item.images.length > 4 && (
+              <div
+                className="flex justify-center items-center text-white text-body-regular absolute top-0 left-0 bg-black/60 w-full h-full"
+                onClick={() => openModal('image', { src: url, imageList: item.images })}
+              >
+                +{item.images.length - 3}
+              </div>
+            )}
+          </div>
         ))}
       </div>
       <div className="w-full flex items-center justify-start gap-2">
-        {/* 하트 토글 구현 예정 */}
-        <div className="text-orange text-body-medium">{item.likeCount}</div>
+          <div className="flex items-center gap-1" onClick={() => setLiked((prev) => !prev)}>
+            {liked ? <HeartFill className="w-4 h-3.5"/> : <Heart className="w-4 h-3.5"/>}
+            <p className="text-body-medium text-orange">{liked ? item.likeCount + 1 : item.likeCount}</p>
+          </div>
         <div className="text-center text-black border border-black-1 px-2 py-1 text-small-regular">{item.rewardPoints} P 지급 완료</div>
       </div>
     </div>

--- a/src/pages/photoReview.tsx
+++ b/src/pages/photoReview.tsx
@@ -26,7 +26,7 @@ export default function PhotoReview() {
       </section>
       <section className="w-full grid grid-cols-3 gap-1">
         {imageList.map((img, idx) => (
-          <img src={img} key={idx} className="w-full aspect-square object-cover" onClick={() => openModal('image', { src: img })} />
+          <img src={img} key={idx} className="w-full aspect-square object-cover" onClick={() => openModal('image', { src: img, imageList: imageList})} />
         ))}
       </section>
     </div>

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -31,7 +31,7 @@ export default function PhotoReview() {
       <section className="w-full grid grid-cols-3 gap-1">
         {imageList.slice(0, 6).map((img, idx) => (
           <div key={idx} className="relative">
-            <img src={img} className="w-full aspect-square object-cover" onClick={() => openModal('image', { src: img })} />
+            <img src={img} className="w-full aspect-square object-cover" onClick={() => openModal('image', { src: img, imageList: imageList })} />
             {idx === 5 && (
               <div
                 className="flex justify-center items-center text-white text-subtitle-semibold absolute top-0 left-0 bg-[#00000099] w-full h-full"


### PR DESCRIPTION
## 🚨 관련 이슈
#77 

## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 별점 starRating 컴포넌트 연결
- 하트 토글 추가
- imageModal 리팩토링
- 사진 상세보기 기능 추가
- 4장 이상 표현 추가

## 😅 미완성 작업 
N/A

## 📢 논의 사항 및 참고 사항 
동일한 리뷰의 사진 보기 기능인데 모달을 추가하는 게 비효율적인 것 같아서, 채현님이 상품 리뷰 쪽에서 사용하신 imageModal을 범용성 있게 props로 전달하는 방식으로 수정했습니다!
지금은 서로 다른 데이터를 참조해서 약간 더러운데(?) api 연결하면서는 아마 동일하게 props 전달하는 식으로 될 것 같습니다.
저는 하나의 리뷰 내에서 사진을 클릭하면, 그 리뷰에서 업로드한 사진만 참조하도록 구현하였는데(사용자가 작성한 리뷰에 대해 보여주는 페이지여서요!), 채현님 쪽에서는 상품 리뷰의 모든 사진을 확인할 때와 각각의 리뷰 사진을 눌렀을 때 동일한 로직으로 되어 있어서 이 부분 기능 논의 필요할 것 같은데 어떻게 생각하시나요? 상품 리뷰인 경우에는 모든 해당 상품 리뷰 사진 이어서 볼 수 있는 것도 나쁘지 않은 것 같아서 .. 🤔
미완성 작업이었던 별점 별 표현, 하트 토글, 4장 이상 표현은 채현님 코드 참고해서 연결하였습니다! 감사합니다🥹❣️