### PR TITLE
[Feat/#79] 오늘의 혜택 UI 구현

### DIFF
--- a/src/components/benefitCard.tsx
+++ b/src/components/benefitCard.tsx
@@ -1,0 +1,11 @@
+type TBenefitCardProps = {
+  content: string;
+};
+
+export default function BenefitCard({ content }: TBenefitCardProps) {
+  return (
+    <div className="w-full bg-black-0 text-black rounded-lg py-5 px-2.5 text-body-regular">
+      <p className="w-25 h-10 text-center">{content}</p>
+    </div>
+  );
+}

--- a/src/constants/myPage/benefitList.ts
+++ b/src/constants/myPage/benefitList.ts
@@ -1,0 +1,22 @@
+export const BENEFIT_LIST = [
+  {
+    id: 1,
+    content: '리뷰 작성하고 100P 받기',
+  },
+  {
+    id: 2,
+    content: '친구 초대하고 500P 받기',
+  },
+  {
+    id: 3,
+    content: '첫 구매 완료하고 500P 받기',
+  },
+  {
+    id: 4,
+    content: '3만원 이상 구매하고 500P 받기',
+  },
+  {
+    id: 5,
+    content: '생일 축하 쿠폰 받기',
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -128,3 +128,10 @@
     line-height: 0.75rem;
   }
 }
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;     /* Firefox */
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;             /* Chrome, Safari, Opera */
+}

--- a/src/pages/mypage/myPage.tsx
+++ b/src/pages/mypage/myPage.tsx
@@ -1,8 +1,10 @@
 import { useNavigate } from 'react-router-dom';
 
+import { BENEFIT_LIST } from '@/constants/myPage/benefitList';
 import { MAIN_FUNCTIONS } from '@/constants/myPage/mainFunctions';
 import { SUB_FUNCTIONS } from '@/constants/myPage/subFunctions';
 
+import BenefitCard from '@/components/benefitCard';
 import BottomBar from '@/components/head_bottom/BottomBar';
 import Header from '@/components/head_bottom/HomeHeader';
 
@@ -55,13 +57,12 @@ export default function MyPage() {
         </section>
 
         <section className="w-full pt-2.5 pb-6">
-          <div className="w-full flex items-center justify-center mb-1">
-            <p className="flex-1 text-subtitle-medium px-5 py-3">오늘의 혜택</p>
-            <button className="w-12 h-12 flex items-center justify-center">
-              <Right />
-            </button>
+          <p className="flex-1 text-subtitle-medium px-5 pt-3 pb-4">오늘의 혜택</p>
+          <div className="w-full flex overflow-x-auto gap-x-2 px-4 scrollbar-hide">
+            {BENEFIT_LIST.map(({ id, content }) => (
+              <BenefitCard key={id} content={content} />
+            ))}
           </div>
-          <div>{/* 오늘의 혜택 컴포넌트 추가 예정 */}</div>
         </section>
 
         <section className="w-full pt-6 pb-20">


### PR DESCRIPTION
## 🚨 관련 이슈
#79 

## ✨ 변경사항
[//]: # (어떤 변경사항이 있었나요? 체크해주세요 !)
- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용
- 기존 버튼 삭제
- 오늘의 혜택 데이터 상수 생성
- 오늘의 혜택 컴포넌트 구현
- 마이페이지에서 오늘의 혜택 UI 구현
- 스크롤바 감추는 css 추가

## 😅 미완성 작업 
N/A

## 📢 논의 사항 및 참고 사항 
PM님께서 오늘의 혜택 기능을 삭제하셔서, 기존 오늘의 혜택에 만들어뒀던 상세 보기 버튼을 삭제하고 상수 데이터를 삽입해서 컴포넌트 스타일링 후 UI로 보여지게 구현하였습니다!
스크롤 바가 생기는 게 안 예뻐서, 찾아보니 scrollbar-hide 유틸리티를 추가해야 해서 index.css에 추가 후 사용하였습니다. 드래그로 스크롤 가능합니다!